### PR TITLE
enable em space split of search words

### DIFF
--- a/app/models/ItemFts.php
+++ b/app/models/ItemFts.php
@@ -47,7 +47,7 @@ __SQL__;
 
     private static function createMatchWord($word){
         $searchWords = array();
-        $words = explode(" ", trim($word));
+        $words = preg_split("/( |　)/", trim($word));
         foreach($words as $word){
             $searchWords[] = FtsUtils::toNgram($word);
         }


### PR DESCRIPTION
change "explode" to "preg_split" so that the search words can be splitted by "space" and "em space".
