### PR TITLE
カスタム認証ドライバーの追加

### DIFF
--- a/app/Authenticate/Driver/OwlUser.php
+++ b/app/Authenticate/Driver/OwlUser.php
@@ -1,0 +1,18 @@
+<?php namespace Owl\Authenticate\Driver;
+
+/**
+ * @copyright (c) owl
+ */
+
+use Illuminate\Auth\GenericUser;
+
+/**
+ * Class OwlUser
+ * Expand of GenericUser for owl.
+ *
+ * @package Owl\Authenticate\Driver
+ */
+class OwlUser extends GenericUser
+{
+    //
+}

--- a/app/Authenticate/Driver/OwlUserProvider.php
+++ b/app/Authenticate/Driver/OwlUserProvider.php
@@ -89,7 +89,7 @@ class OwlUserProvider implements UserProvider
 
         foreach ($credentials as $key => $value) {
             if (!str_contains($key, 'password')) {
-                $wkey = [$key => $value];
+                $wkey[] = [$key => $value];
             }
         }
 

--- a/app/Authenticate/Driver/OwlUserProvider.php
+++ b/app/Authenticate/Driver/OwlUserProvider.php
@@ -69,10 +69,7 @@ class OwlUserProvider implements UserProvider
      */
     public function updateRememberToken(Authenticatable $user, $token)
     {
-        $this->userService->updateToken(
-            $user->getAuthIdentifier(),
-            $token
-        );
+        $this->userService->updateToken($user->getAuthIdentifier(), $token);
     }
 
     /**
@@ -83,7 +80,22 @@ class OwlUserProvider implements UserProvider
      */
     public function retrieveByCredentials(array $credentials)
     {
-        return;
+        // Do not allowing login without password.
+        if (!array_key_exists('password', $credentials)) {
+            return;
+        }
+
+        $wkey = [];
+
+        foreach ($credentials as $key => $value) {
+            if (!str_contains($key, 'password')) {
+                $wkey = [$key => $value];
+            }
+        }
+
+        $user = $this->userService->getUser($wkey);
+
+        return $this->getOwlUser($user);
     }
 
     /**
@@ -95,7 +107,14 @@ class OwlUserProvider implements UserProvider
      */
     public function validateCredentials(Authenticatable $user, array $credentials)
     {
-        return true;
+        $password = $user->getAuthPassword();
+
+        if (password_verify($credentials['password'], $password)) {
+            return true;
+        }
+
+        // 不正なパスワード
+        return false;
     }
 
     /**

--- a/app/Authenticate/Driver/OwlUserProvider.php
+++ b/app/Authenticate/Driver/OwlUserProvider.php
@@ -85,15 +85,9 @@ class OwlUserProvider implements UserProvider
             return;
         }
 
-        $wkey = [];
+        unset($credentials['password']);
 
-        foreach ($credentials as $key => $value) {
-            if (!str_contains($key, 'password')) {
-                $wkey[] = [$key => $value];
-            }
-        }
-
-        $user = $this->userService->getUser($wkey);
+        $user = $this->userService->getUser($credentials);
 
         return $this->getOwlUser($user);
     }
@@ -122,7 +116,7 @@ class OwlUserProvider implements UserProvider
      *
      * @param mixed  $user
      *
-     * @return OwlUser
+     * @return OwlUser|null
      */
     protected function getOwlUser($user)
     {

--- a/app/Authenticate/Driver/OwlUserProvider.php
+++ b/app/Authenticate/Driver/OwlUserProvider.php
@@ -76,7 +76,7 @@ class OwlUserProvider implements UserProvider
      * Retrieve a user by the given credentials.
      *
      * @param array $credentials
-     * @return null
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
      */
     public function retrieveByCredentials(array $credentials)
     {
@@ -103,7 +103,7 @@ class OwlUserProvider implements UserProvider
      *
      * @param \Illuminate\Contracts\Auth\Authenticatable $user
      * @param array $credentials
-     * @return true
+     * @return bool
      */
     public function validateCredentials(Authenticatable $user, array $credentials)
     {

--- a/app/Authenticate/Driver/OwlUserProvider.php
+++ b/app/Authenticate/Driver/OwlUserProvider.php
@@ -1,0 +1,118 @@
+<?php namespace Owl\Authenticate\Driver;
+
+/**
+ * @copyright (c) owl
+ */
+
+use Illuminate\Contracts\Auth\UserProvider;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Owl\Authenticate\Driver\OwlUser;
+use Owl\Services\UserService;
+
+/**
+ * Class OwlUserProvider
+ *
+ * @package Owl\Authenticate\Driver
+ */
+class OwlUserProvider implements UserProvider
+{
+    /** @var UserService */
+    protected $userService;
+
+    /** @var AuthService */
+    protected $authService;
+
+    /**
+     * Create constructor.
+     *
+     * @param UserService  $userService
+     * @param AuthService  $authService
+     */
+    public function __construct(
+        UserService $userService,
+        AuthService $authService
+    ) {
+        $this->userService = $userService;
+        $this->authService = $authService;
+    }
+
+    /**
+     * Retrieve a user by unique identifer.
+     *
+     * @param mixed  $identifier
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public function retrieveById($identifier)
+    {
+        $user = $this->userService->getById($identifier);
+        return $this->getOwlUser($user);
+    }
+
+    /**
+     * Retrieve a user by unique token and identifier.
+     *
+     * @param mixed   $identifier
+     * @param string  $token
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public function retrieveByToken($identifier, $token)
+    {
+        $user = $this->userService->getByToken($token);
+
+        if (!$user) {
+            return null;
+        }
+
+        return $this->getOwlUser($user);
+    }
+
+    /**
+     * Update the "remember me" token for the given user in storage.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     * @param string  $token
+     */
+    public function updateRememberToken(Authenticatable $user, $token)
+    {
+        // TODO
+    }
+
+    /**
+     * Retrieve a user by the given credentials.
+     *
+     * @param array $credentials
+     * @return null
+     */
+    public function retrieveByCredentials(array $credentials)
+    {
+        return;
+    }
+
+    /**
+     * Validate a user against the given credentials.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     * @param array $credentials
+     * @return true
+     */
+    public function validateCredentials(Authenticatable $user, array $credentials)
+    {
+        return true;
+    }
+
+    /**
+     * Get the owl user.
+     *
+     * @param mixed  $user
+     *
+     * @return OwlUser
+     */
+    protected function getGitHubUser($user)
+    {
+        if(!is_null($user)) {
+            return new OwlUser((array) $user);
+        }
+    }
+}

--- a/app/Authenticate/Driver/OwlUserProvider.php
+++ b/app/Authenticate/Driver/OwlUserProvider.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Owl\Authenticate\Driver\OwlUser;
 use Owl\Services\UserService;
-use Owl\Services\AuthService;
 
 /**
  * Class OwlUserProvider
@@ -20,21 +19,14 @@ class OwlUserProvider implements UserProvider
     /** @var UserService */
     protected $userService;
 
-    /** @var AuthService */
-    protected $authService;
-
     /**
      * Create constructor.
      *
      * @param UserService  $userService
-     * @param AuthService  $authService
      */
-    public function __construct(
-        UserService $userService,
-        AuthService $authService
-    ) {
+    public function __construct(UserService $userService)
+    {
         $this->userService = $userService;
-        $this->authService = $authService;
     }
 
     /**
@@ -113,7 +105,7 @@ class OwlUserProvider implements UserProvider
      *
      * @return OwlUser
      */
-    protected function getGitHubUser($user)
+    protected function getOwlUser($user)
     {
         if (!is_null($user)) {
             return new OwlUser((array) $user);

--- a/app/Authenticate/Driver/OwlUserProvider.php
+++ b/app/Authenticate/Driver/OwlUserProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Owl\Authenticate\Driver\OwlUser;
 use Owl\Services\UserService;
+use Owl\Services\AuthService;
 
 /**
  * Class OwlUserProvider

--- a/app/Authenticate/Driver/OwlUserProvider.php
+++ b/app/Authenticate/Driver/OwlUserProvider.php
@@ -76,7 +76,10 @@ class OwlUserProvider implements UserProvider
      */
     public function updateRememberToken(Authenticatable $user, $token)
     {
-        // TODO
+        $this->userService->updateToken(
+            $user->getAuthIdentifier(),
+            $token
+        );
     }
 
     /**
@@ -111,7 +114,7 @@ class OwlUserProvider implements UserProvider
      */
     protected function getGitHubUser($user)
     {
-        if(!is_null($user)) {
+        if (!is_null($user)) {
             return new OwlUser((array) $user);
         }
     }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -44,8 +44,7 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->app['auth']->extend('owl', function ($app) {
             return new Guard(
-                $app->make('\Owl\Authenticate\Driver\OwlUserProvider'),
-                $app['session.store'], null
+                $app->make('\Owl\Authenticate\Driver\OwlUserProvider'), $app['session.store']
             );
         });
     }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,52 @@
+<?php namespace Owl\Providers;
+
+/**
+ * @copyright (c) owl
+ */
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Auth\Guard;
+
+/**
+ * Class AuthServiceProvider
+ * 認証周りのインスタンス管理プロバイダー
+ */
+class AuthServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->registerAuthDrivers();
+    }
+
+    /**
+     * Register any application services.
+     *
+     * This service provider is a great spot to register your various container
+     * bindings with the application. As you can see, we are registering our
+     * "Registrar" implementation here. You can add your own bindings too!
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //
+    }
+
+    /**
+     * カスタムAuth Driverをサービスコンテナに登録
+     */
+    protected function registerAuthDrivers()
+    {
+        $this->app['auth']->extend('owl', function ($app) {
+            return new Guard(
+                $app->make('\Owl\Authenticate\Driver\OwlUserProvider'),
+                $app['session.store'], null
+            );
+        });
+    }
+}

--- a/app/Repositories/Fluent/AbstractFluent.php
+++ b/app/Repositories/Fluent/AbstractFluent.php
@@ -27,14 +27,14 @@ abstract class AbstractFluent
     /**
      * Find a record.
      *
-     * @param array  $wkey
-     * @param
+     * @param array  $conditions
+     *
      * @return \stcClass | null
      */
-    public function find(array $wkey)
+    public function find(array $conditions)
     {
         return \DB::table($this->getTableName())
-            ->where($wkey)
+            ->where($conditions)
             ->first();
     }
 

--- a/app/Repositories/Fluent/AbstractFluent.php
+++ b/app/Repositories/Fluent/AbstractFluent.php
@@ -25,6 +25,20 @@ abstract class AbstractFluent
     abstract public function getTableName();
 
     /**
+     * Find a record.
+     *
+     * @param array  $wkey
+     * @param
+     * @return \stcClass | null
+     */
+    public function get(array $wkey)
+    {
+        return \DB::table($this->getTableName())
+            ->where($wkey)
+            ->first();
+    }
+
+    /**
      * Insert a record.
      *
      * @param $params array ：key(column name) => value

--- a/app/Repositories/Fluent/AbstractFluent.php
+++ b/app/Repositories/Fluent/AbstractFluent.php
@@ -31,7 +31,7 @@ abstract class AbstractFluent
      * @param
      * @return \stcClass | null
      */
-    public function get(array $wkey)
+    public function find(array $wkey)
     {
         return \DB::table($this->getTableName())
             ->where($wkey)

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -173,6 +173,22 @@ class UserService extends Service
     }
 
     /**
+     * Update the "remember me" token by user ID.
+     *
+     * @param int     $userId
+     * @param string  $token
+     *
+     * @return bool
+     */
+    public function updateToken($userId, $token)
+    {
+        return !!$this->loginTokenRepo->update(
+            [ 'token'   => $token  ],
+            [ 'user_id' => $userId ]
+        );
+    }
+
+    /**
      * @return array
      */
     public function getOwners()

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -182,10 +182,10 @@ class UserService extends Service
      */
     public function updateToken($userId, $token)
     {
-        return (bool) $this->loginTokenRepo->update(
-            [ 'token'   => $token  ],
-            [ 'user_id' => $userId ]
-        );
+        $params = compact('token');
+        $wkey   = compact('user_id');
+
+        return (bool) $this->loginTokenRepo->update($params, $wkey);
     }
 
     /**

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -194,7 +194,7 @@ class UserService extends Service
     public function updateToken($userId, $token)
     {
         $params = compact('token');
-        $wkey   = compact('user_id');
+        $wkey   = ['user_id' => $userId];
 
         return (bool) $this->loginTokenRepo->update($params, $wkey);
     }

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -116,7 +116,7 @@ class UserService extends Service
      */
     public function getUser(array $wkey)
     {
-        return $this->userRepo->get($wkey);
+        return $this->userRepo->find($wkey);
     }
 
     /**

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -109,6 +109,17 @@ class UserService extends Service
     }
 
     /**
+     * Get a user by specified keys.
+     *
+     * @param array  $wkey
+     * @return \stdClass | null
+     */
+    public function getUser(array $wkey)
+    {
+        return $this->userRepo->get($wkey);
+    }
+
+    /**
      * Get a user by user id.
      *
      * @param int  $id

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -182,7 +182,7 @@ class UserService extends Service
      */
     public function updateToken($userId, $token)
     {
-        return !!$this->loginTokenRepo->update(
+        return (bool) $this->loginTokenRepo->update(
             [ 'token'   => $token  ],
             [ 'user_id' => $userId ]
         );

--- a/config/app.php
+++ b/config/app.php
@@ -154,6 +154,7 @@ return [
       'Owl\Providers\MacroServiceProvider',
       'Owl\Providers\ValidatorServiceProvider',
       'Owl\Providers\RepositoriesServiceProvider',
+      'Owl\Providers\AuthServiceProvider',
 
     ],
 

--- a/tests/Authenticate/Driver/OwlUserProviderTest.php
+++ b/tests/Authenticate/Driver/OwlUserProviderTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use Mockery as m;
+use Mockery\MockInterface as i;
+use Owl\Authenticate\Driver\OwlUserProvider;
+use Owl\Authenticate\Driver\OwlUser;
+use Owl\Services\UserService;
+
+class OwlUserProviderTest extends \TestCase
+{
+    /** @var i */
+    protected $userService;
+
+    /** @var string */
+    protected $className = 'Owl\Authenticate\Driver\OwlUserProvider';
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->userService = m::mock('Owl\Services\UserService');
+        $this->app->bind('Owl\Services\UserService', function () {
+            return $this->userService;
+        });
+    }
+
+    public function testValidInstance()
+    {
+        $service = $this->app->make($this->className);
+        $this->assertInstanceOf(
+            $this->className, $service
+        );
+    }
+
+    public function testShouldReturnOwlUser()
+    {
+        $this->userService->shouldReceive('getById')->andReturn([]);
+        $this->userService->shouldReceive('getByToken')->andReturn(['name' => 'dummy']);
+        $owlUserProvider = $this->app->make($this->className);
+
+        $this->assertInstanceOf(
+            'Owl\Authenticate\Driver\OwlUser',
+            $owlUserProvider->retrieveById(9999)
+        );
+        $this->assertInstanceOf(
+            'Owl\Authenticate\Driver\OwlUser',
+            $owlUserProvider->retrieveByToken(9999, 'token')
+        );
+    }
+
+    public function testShouldReturnNull()
+    {
+        $this->userService->shouldReceive('getById')->andReturn(null);
+        $this->userService->shouldReceive('getByToken')->andReturn(false);
+        $owlUserProvider = $this->app->make($this->className);
+
+        $this->assertNull($owlUserProvider->retrieveById(9999));
+        $this->assertNull($owlUserProvider->retrieveByToken(9999, 'token'));
+    }
+
+    public function testShouldUpdateRememberToken()
+    {
+        $this->userService->shouldReceive('updateToken')->andReturn(null);
+        $owlUser = new OwlUser(['id' => 9999]);
+        $owlUserProvider = $this->app->make($this->className);
+
+        $this->assertNull($owlUserProvider->updateRememberToken($owlUser, 'token'));
+    }
+
+    public function testRetrieveByCredentialsReturnsNull()
+    {
+        $owlUserProvider = $this->app->make($this->className);
+
+        $this->assertNull($owlUserProvider->retrieveByCredentials([]));
+    }
+
+    public function testValidateCredentialsReturnTrue()
+    {
+        $owlUser = new OwlUser([]);
+        $owlUserProvider = $this->app->make($this->className);
+
+        $this->assertTrue($owlUserProvider->validateCredentials($owlUser, []));
+    }
+}

--- a/tests/Services/UserServiceTest.php
+++ b/tests/Services/UserServiceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Mockery as m;
+use Mockery\MockInterface as i;
+use Illuminate\Database\DatabaseManager;
+use Owl\Services\UserService;
+
+class UserServiceTest extends \TestCase
+{
+    /** @var string */
+    protected $serviceName   = 'Owl\Services\UserService';
+
+    public function testValidInstance()
+    {
+        $service = $this->app->make($this->serviceName);
+        $this->assertInstanceOf(
+            $this->serviceName, $service
+        );
+    }
+
+    public function testGetUserMethod()
+    {
+        \DB::shouldReceive('table->where->first')->andReturn('user');
+        $service = $this->app->make($this->serviceName);
+
+        $this->assertEquals('user', $service->getUser([]));
+    }
+}

--- a/tests/Services/UserServiceTest.php
+++ b/tests/Services/UserServiceTest.php
@@ -2,7 +2,6 @@
 
 use Mockery as m;
 use Mockery\MockInterface as i;
-use Illuminate\Database\DatabaseManager;
 use Owl\Services\UserService;
 
 class UserServiceTest extends \TestCase


### PR DESCRIPTION
Issue #67

owl用にLaravel認証ドライバーを拡張したクラスを追加しました。
Remember Tokenアップデート用にサービスメソッドも1つ追加しています。
利用方法は主に以下のとおりです。

```php
¥Auth::driver('owl')->loginUsingId($userId); // owlユーザIDを使ってログイン
¥Auth::driver('owl')->guest(); // ログイン済みかどうかをbool値で取得
¥Auth::driver('owl')->login($owlUser); // ¥Owl¥Authenticate¥Driver¥OwlUserインスタンスを渡してログイン(使い勝手悪いので使わないと思います…)
¥Auth::driver('owl')->logout(); // ログアウト
```

`OwlUserProvider`でいくつかのメソッドを雑実装(`return true`してるだけ)してる理由は`Auth`ファサードないしは`AuthManager`を利用する際に`login()`, `loginUsingId()`、`guest()`,  `user()`あたりを使用できればowlでは事足りると判断したためです。(実装してもいいですが、正直使わないと思うので…)

レビューお願いします。
