### PR TITLE
エラーハンドリングを修正

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -49,7 +49,7 @@ class Handler extends ExceptionHandler {
         $routeName = $this->getRouteName($request->route());
 
         if ($e instanceof NotFoundHttpException) {
-            // 記事ページを参照しようとしてエラーの場合、404ページを表示
+            // 記事ページを参照しようとしてエラーの場合、アイテムページ用404ページを表示
             if ($routeName === 'items.show') {
                 return response()->view('errors.missing_item', [], 404);
             }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -1,46 +1,83 @@
 <?php namespace Owl\Exceptions;
 
+/**
+ * @copyright (c) owl
+ */
+
 use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
+/**
+ * Class Handler
+ *
+ * @package Owl\Exceptions
+ */
 class Handler extends ExceptionHandler {
 
-	/**
-	 * A list of the exception types that should not be reported.
-	 *
-	 * @var array
-	 */
-	protected $dontReport = [
-		'Symfony\Component\HttpKernel\Exception\HttpException'
-	];
+    /**
+     * A list of the exception types that should not be reported.
+     *
+     * @var array
+     */
+    protected $dontReport = [
+        'Symfony\Component\HttpKernel\Exception\HttpException'
+    ];
 
-	/**
-	 * Report or log an exception.
-	 *
-	 * This is a great spot to send exceptions to Sentry, Bugsnag, etc.
-	 *
-	 * @param  \Exception  $e
-	 * @return void
-	 */
-	public function report(Exception $e)
-	{
-		return parent::report($e);
-	}
-
-	/**
-	 * Render an exception into an HTTP response.
-	 *
-	 * @param  \Illuminate\Http\Request  $request
-	 * @param  \Exception  $e
-	 * @return \Illuminate\Http\Response
-	 */
-	public function render($request, Exception $e)
+    /**
+     * Report or log an exception.
+     *
+     * This is a great spot to send exceptions to Sentry, Bugsnag, etc.
+     *
+     * @param  \Exception  $e
+     * @return void
+     */
+    public function report(Exception $e)
     {
-        if($e instanceof NotFoundHttpException) {
+        return parent::report($e);
+    }
+
+    /**
+     * Render an exception into an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Exception  $e
+     * @return \Illuminate\Http\Response
+     */
+    public function render($request, Exception $e)
+    {
+        $routeName = $this->getRouteName($request->route());
+
+        if ($e instanceof NotFoundHttpException) {
             return response()->view('errors.missing', [], 404);
         }
-		return parent::render($request, $e);
-	}
 
+        // 記事ページを参照しようとしてエラーの場合、404ページを表示
+        if ($routeName === 'items.show') {
+            return response()->view('errors.missing', [], 404);
+        }
+
+        // 本番環境の場合、500テンプレートを返す
+        if (app()->environment() === 'production') {
+            return response()->view('errors.500', [], 500);
+        }
+
+        return parent::render($request, $e);
+    }
+
+    /**
+     * Get route name from route instance safety.
+     *
+     * @param mixed  $route
+     *
+     * @return string|null
+     */
+    protected function getRouteName($route)
+    {
+        if ($route instanceof \Illuminate\Routeing\Route) {
+            return $route->getName();
+        }
+
+        return null;
+    }
 }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -49,15 +49,15 @@ class Handler extends ExceptionHandler {
         $routeName = $this->getRouteName($request->route());
 
         if ($e instanceof NotFoundHttpException) {
+            // 記事ページを参照しようとしてエラーの場合、404ページを表示
+            if ($routeName === 'items.show') {
+                return response()->view('errors.missing_item', [], 404);
+            }
+
             return response()->view('errors.missing', [], 404);
         }
 
-        // 記事ページを参照しようとしてエラーの場合、404ページを表示
-        if ($routeName === 'items.show') {
-            return response()->view('errors.missing', [], 404);
-        }
-
-        // 本番環境の場合、500テンプレートを返す
+        // 本番環境の場合の処理
         if (app()->environment() === 'production') {
             return response()->view('errors.500', [], 500);
         }

--- a/app/Repositories/Fluent/ItemRepository.php
+++ b/app/Repositories/Fluent/ItemRepository.php
@@ -46,7 +46,7 @@ class ItemRepository extends AbstractFluent implements ItemRepositoryInterface
      * Get a item by open item id with comments.
      *
      * @param int $open_item_id
-     * @return stdClass
+     * @return \stdClass|null
      */
     public function getByOpenItemIdWithComment($open_item_id)
     {
@@ -371,8 +371,8 @@ class ItemRepository extends AbstractFluent implements ItemRepositoryInterface
 
     /**
      * get item tags array
-     * 
-     * @param object $item 
+     *
+     * @param object $item
      * @return array
      */
     public function getTagsToArray($item)

--- a/app/Repositories/Fluent/ItemRepository.php
+++ b/app/Repositories/Fluent/ItemRepository.php
@@ -52,6 +52,11 @@ class ItemRepository extends AbstractFluent implements ItemRepositoryInterface
     {
         // @FIXME
         $item = \DB::table('items')->where('open_item_id', $open_item_id)->first();
+
+        if (is_null($item)) {
+            return null;
+        }
+
         $item->user = \DB::table('users')->where('id', $item->user_id)->first();
         $comments = \DB::table('comments')->where('item_id', $item->id)->get();
         $i = 0;

--- a/app/Repositories/ItemRepositoryInterface.php
+++ b/app/Repositories/ItemRepositoryInterface.php
@@ -22,7 +22,7 @@ interface ItemRepositoryInterface
      * Get a item by open item id with comments.
      *
      * @param int $open_item_id
-     * @return Illuminate\Database\Eloquent\Model
+     * @return \stdClass|null
      */
     public function getByOpenItemIdWithComment($open_item_id);
 
@@ -107,8 +107,8 @@ interface ItemRepositoryInterface
 
     /**
      * get item tags array
-     * 
-     * @param object $item 
+     *
+     * @param object $item
      * @return array
      */
     public function getTagsToArray($item);

--- a/features/ItemTest.feature
+++ b/features/ItemTest.feature
@@ -91,9 +91,3 @@ Feature: Item Test
         Then I should be on "/items/create"
         Then I should see "タイトルの長さは255文字以下である必要があります"
         Then the response status code should be 200
-
-    Scenario: item page not found
-        Given I am on the homepage
-        When I go to "/items/detaramenaitemid"
-        Then I should see "お探しのページは見つかりませんでした"
-        Then the response status code should be 404

--- a/features/ItemTest.feature
+++ b/features/ItemTest.feature
@@ -91,3 +91,9 @@ Feature: Item Test
         Then I should be on "/items/create"
         Then I should see "タイトルの長さは255文字以下である必要があります"
         Then the response status code should be 200
+
+    Scenario: item page not found
+        Given I am on the homepage
+        When I go to "/items/detaramenaitemid"
+        Then I should see "お探しのページは見つかりませんでした"
+        Then the response status code should be 404

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,0 +1,54 @@
+{{-- 500ページ --}}
+
+<html>
+    <head>
+        <title>owl internal server error</title>
+        <style>
+            body {
+                background-color: #fcfcfc;
+            }
+
+            h1, p {
+                text-align: center;
+            }
+
+            h1 {
+                font-size: 28px;
+            }
+
+            img {
+                width: 150px;
+            }
+
+            #container {
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                margin: auto;
+                width: 500px;
+                height: 300px;
+            }
+
+            .logo {
+                text-align: center;
+            }
+        </style>
+    </head>
+
+    <body>
+        <div id="container">
+            <div class="logo">
+                <img src="/img/owl_logo.png">
+            </div>
+            <h1>ページが表示できません...</h1>
+            <p>
+            ご迷惑をおかけして申し訳ありません。<br />
+            エラーが発生しました。<br />
+            管理者までお問い合わせください。
+            </p>
+
+        </div>
+    </body>
+</html>

--- a/resources/views/errors/missing_item.blade.php
+++ b/resources/views/errors/missing_item.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.master')
+
+@section('title')
+404 Not Found | Owl
+@stop
+
+@section('navbar-menu')
+    @include('layouts.navbar-menu')
+@stop
+
+@section('contents-pagehead')
+<p class="page-title">404 Not Found</p>
+@stop
+
+@section('contents-main')
+    <h4>お探しの記事は見つかりませんでした</h4>
+@stop


### PR DESCRIPTION
Issue #123 

以下の様に修正しています。

- NotFoundExceptionかつ、アイテムページの場合返すviewを変更
- Handlerに処理が渡り、`APP_ENV`が`production`の場合、`errors.500.blade.php`を返却
- 記事データ取得時の処理の修正(https://github.com/owl/owl/issues/123#issuecomment-195710478)

最初はExceptionかつアイテムページの場合全部404にしちゃおうかなと思ったんですが内部的に500の状態を404で返すのって普通に握りつぶしでしかないので都度バグ修正してハンドリングして`abort(404)`が正解かなと思いました。
マージのご検討を :hocho: 

(ちなみに500ページのキャプチャはこちら)
![](https://i.gyazo.com/cc5c6239d3f810a481b04d6f7f227d03.png)