### PR TITLE
Enable MySQL Driver

### DIFF
--- a/.env.behat
+++ b/.env.behat
@@ -2,11 +2,6 @@ APP_ENV=acceptance
 APP_DEBUG=true
 APP_KEY=SomeRandomString
 
-DB_HOST=localhost
-DB_DATABASE=homestead
-DB_USERNAME=homestead
-DB_PASSWORD=secret
-
 CACHE_DRIVER=file
 SESSION_DRIVER=file
 
@@ -22,3 +17,10 @@ NOTIFICATION_ENABLE=false
 # slack webhook
 SLACK_NOTIFICATION_ENABLE=false
 SLACK_WEBHOOK_URL=null
+
+# database
+DB_DRIVER=sqlite
+DB_HOST=127.0.0.1
+DB_DATABASE=owl
+DB_USERNAME=developer
+DB_PASSWORD=developer

--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,10 @@ NOTIFICATION_ENABLE=false
 # slack webhook
 SLACK_NOTIFICATION_ENABLE=false
 SLACK_WEBHOOK_URL=null
+
+# database
+DB_DRIVER=sqlite
+DB_HOST=127.0.0.1
+DB_DATABASE=owl
+DB_USERNAME=developer
+DB_PASSWORD=developer

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -28,8 +28,8 @@ class SearchController extends Controller
         $offset = $this->calcOffset(\Input::get('page'));
         $results = $this->searchService->itemMatch($q, $this->perPage, $offset);
         if (count($results) > 0) {
-            $res = $this->searchService->itemMatchCount($q);
-            $pagination = new Paginator($results, $res[0]->count, $this->perPage, null, array('path' => '/search'));
+            $count = $this->searchService->itemMatchCount($q);
+            $pagination = new Paginator($results, $count, $this->perPage, null, array('path' => '/search'));
         }
         $users = $this->userService->getLikeUsername($q);
         $users_array = $this->userService->getUsersToArray($users);

--- a/app/Providers/RepositoriesServiceProvider.php
+++ b/app/Providers/RepositoriesServiceProvider.php
@@ -30,11 +30,11 @@ class RepositoriesServiceProvider extends ServiceProvider
         \App::bind('Owl\Repositories\TemplateRepositoryInterface', 'Owl\Repositories\Fluent\TemplateRepository');
         \App::bind('Owl\Repositories\TagRepositoryInterface', 'Owl\Repositories\Fluent\TagRepository');
         \App::bind('Owl\Repositories\ItemRepositoryInterface', 'Owl\Repositories\Fluent\ItemRepository');
-        if(env('DB_DRIVER', 'sqlite') == 'mysql') {
+        if (env('DB_DRIVER', 'sqlite') == 'mysql') {
             \App::bind('Owl\Repositories\ItemFtsRepositoryInterface',
                 'Owl\Repositories\Fluent\MySQL\ItemFtsRepository');
             \App::bind('Owl\Repositories\TagFtsRepositoryInterface', 'Owl\Repositories\Fluent\MySQL\TagFtsRepository');
-        }else{
+        } else {
             \App::bind('Owl\Repositories\ItemFtsRepositoryInterface', 'Owl\Repositories\Fluent\ItemFtsRepository');
             \App::bind('Owl\Repositories\TagFtsRepositoryInterface', 'Owl\Repositories\Fluent\TagFtsRepository');
         }

--- a/app/Providers/RepositoriesServiceProvider.php
+++ b/app/Providers/RepositoriesServiceProvider.php
@@ -29,9 +29,15 @@ class RepositoriesServiceProvider extends ServiceProvider
         \App::bind('Owl\Repositories\StockRepositoryInterface', 'Owl\Repositories\Fluent\StockRepository');
         \App::bind('Owl\Repositories\TemplateRepositoryInterface', 'Owl\Repositories\Fluent\TemplateRepository');
         \App::bind('Owl\Repositories\TagRepositoryInterface', 'Owl\Repositories\Fluent\TagRepository');
-        \App::bind('Owl\Repositories\TagFtsRepositoryInterface', 'Owl\Repositories\Fluent\TagFtsRepository');
         \App::bind('Owl\Repositories\ItemRepositoryInterface', 'Owl\Repositories\Fluent\ItemRepository');
-        \App::bind('Owl\Repositories\ItemFtsRepositoryInterface', 'Owl\Repositories\Fluent\ItemFtsRepository');
+        if(env('DB_DRIVER', 'sqlite') == 'mysql') {
+            \App::bind('Owl\Repositories\ItemFtsRepositoryInterface',
+                'Owl\Repositories\Fluent\MySQL\ItemFtsRepository');
+            \App::bind('Owl\Repositories\TagFtsRepositoryInterface', 'Owl\Repositories\Fluent\MySQL\TagFtsRepository');
+        }else{
+            \App::bind('Owl\Repositories\ItemFtsRepositoryInterface', 'Owl\Repositories\Fluent\ItemFtsRepository');
+            \App::bind('Owl\Repositories\TagFtsRepositoryInterface', 'Owl\Repositories\Fluent\TagFtsRepository');
+        }
         \App::bind('Owl\Repositories\ItemHistoryRepositoryInterface', 'Owl\Repositories\Fluent\ItemHistoryRepository');
         \App::bind('Owl\Repositories\UserRepositoryInterface', 'Owl\Repositories\Fluent\UserRepository');
         \App::bind('Owl\Repositories\UserRoleRepositoryInterface', 'Owl\Repositories\Fluent\UserRoleRepository');

--- a/app/Repositories/Fluent/ItemFtsRepository.php
+++ b/app/Repositories/Fluent/ItemFtsRepository.php
@@ -113,7 +113,7 @@ __SQL__;
      * matchCount
      *
      * @param string $str
-     * @return array
+     * @return int $count
      */
     public function matchCount($str)
     {

--- a/app/Repositories/Fluent/ItemRepository.php
+++ b/app/Repositories/Fluent/ItemRepository.php
@@ -280,8 +280,8 @@ class ItemRepository extends AbstractFluent implements ItemRepositoryInterface
     {
         return \DB::table('items')
                     ->join('users', 'items.user_id', '=', 'users.id')
-                    ->join('tags', 'tags.id', '=', 'item_tag.tag_id')
                     ->join('item_tag', 'items.id', '=', 'item_tag.item_id')
+                    ->join('tags', 'tags.id', '=', 'item_tag.tag_id')
                     ->where('tags.id', $tag_id)
                     ->where('published', '2')
                     ->select('users.email', 'users.username', 'items.open_item_id', 'items.updated_at', 'items.title')

--- a/app/Repositories/Fluent/MySQL/ItemFtsRepository.php
+++ b/app/Repositories/Fluent/MySQL/ItemFtsRepository.php
@@ -96,7 +96,7 @@ class ItemFtsRepository extends AbstractFluent implements ItemFtsRepositoryInter
      * matchCount
      *
      * @param string $str
-     * @return array
+     * @return int $count
      */
     public function matchCount($str)
     {

--- a/app/Repositories/Fluent/MySQL/TagFtsRepository.php
+++ b/app/Repositories/Fluent/MySQL/TagFtsRepository.php
@@ -1,0 +1,64 @@
+<?php namespace Owl\Repositories\Fluent\MySQL;
+
+use Owl\Repositories\TagFtsRepositoryInterface;
+use Owl\Libraries\FtsUtils;
+use Owl\Repositories\Fluent\AbstractFluent;
+
+class TagFtsRepository extends AbstractFluent implements TagFtsRepositoryInterface
+{
+    protected $table = 'tags';
+
+    /**
+     * Get a table name.
+     *
+     * @return string
+     */
+    public function getTableName()
+    {
+        return $this->table;
+    }
+
+    /**
+     * get a tagFts data or Create a tagFts data by ID and Words.
+     *
+     * @param int $tag_id
+     * @param string $words
+     * @return stdClass
+     */
+    public function firstOrCreateByIdAndWords($tag_id, $words)
+    {
+        return array();
+    }
+
+    /**
+     * get a tagFts by tag_id.
+     *
+     * @param int $id
+     * @return void
+     */
+    public function getById($tag_id)
+    {
+        return \DB::table($this->getTableName())
+            ->where($this->getTableName().'.tag_id', $tag_id)
+            ->first();
+    }
+
+    /**
+     * get tags data by string for FullTextSearch.
+     *
+     * @param string $string
+     * @param int $limit
+     * @param int $offset
+     * @return array
+     */
+    public function match($str, $limit = 10, $offset = 0)
+    {
+        return \DB::table($this->getTableName())
+            ->whereRaw("match(tags.name) against (? in boolean mode)", [$str])
+            ->select(
+                'tags.name'
+            )
+            ->orderBy('tags.updated_at', 'desc')
+            ->skip($offset)->take($limit)->get();
+    }
+}

--- a/app/Repositories/Fluent/MySQL/TagFtsRepository.php
+++ b/app/Repositories/Fluent/MySQL/TagFtsRepository.php
@@ -23,7 +23,7 @@ class TagFtsRepository extends AbstractFluent implements TagFtsRepositoryInterfa
      *
      * @param int $tag_id
      * @param string $words
-     * @return stdClass
+     * @return array
      */
     public function firstOrCreateByIdAndWords($tag_id, $words)
     {

--- a/app/Repositories/Fluent/TagFtsRepository.php
+++ b/app/Repositories/Fluent/TagFtsRepository.php
@@ -22,7 +22,7 @@ class TagFtsRepository extends AbstractFluent implements TagFtsRepositoryInterfa
      *
      * @param int $tag_id
      * @param string $words
-     * @return stdClass
+     * @return array
      */
     public function firstOrCreateByIdAndWords($tag_id, $words)
     {

--- a/app/Repositories/ItemFtsRepositoryInterface.php
+++ b/app/Repositories/ItemFtsRepositoryInterface.php
@@ -43,7 +43,7 @@ interface ItemFtsRepositoryInterface
      * matchCount
      *
      * @param string $str
-     * @return array
+     * @return int $count
      */
     public function matchCount($str);
 }

--- a/config/database.php
+++ b/config/database.php
@@ -26,7 +26,7 @@ return [
 	|
 	*/
 
-	'default' => 'sqlite',
+	'default' => env('DB_DRIVER', 'sqlite'),
 
 	/*
 	|--------------------------------------------------------------------------
@@ -61,7 +61,7 @@ return [
 			'charset'   => 'utf8',
 			'collation' => 'utf8_unicode_ci',
 			'prefix'    => '',
-			'strict'    => false,
+			'strict'    => true,
 		],
 
 		'pgsql' => [

--- a/database/migrations/2014_08_19_164055_create_full_text_search_related_tables.php
+++ b/database/migrations/2014_08_19_164055_create_full_text_search_related_tables.php
@@ -14,7 +14,7 @@ class CreateFullTextSearchRelatedTables extends Migration {
 	 */
 	public function up()
 	{
-		if(env('DB_DRIVER') === 'mysql'){
+		if (env('DB_DRIVER') === 'mysql') {
 			DB::statement('ALTER TABLE items MODIFY COLUMN title varchar(255)
                              CHARACTER SET \'utf8mb4\' COLLATE \'utf8mb4_general_ci\'');
 			DB::statement('ALTER TABLE items MODIFY COLUMN body text
@@ -39,13 +39,13 @@ class CreateFullTextSearchRelatedTables extends Migration {
 	 */
 	public function down()
 	{
-		if(env('DB_DRIVER') === 'mysql') {
+		if (env('DB_DRIVER') === 'mysql') {
+			DB::statement('ALTER TABLE items DROP INDEX ft_item');
 			DB::statement('ALTER TABLE items MODIFY COLUMN title varchar(255)
                              CHARACTER SET \'utf8mb4\' COLLATE \'utf8mb4_unicode_ci\'');
 			DB::statement('ALTER TABLE items MODIFY COLUMN body text
                              CHARACTER SET \'utf8mb4\' COLLATE \'utf8mb4_unicode_ci\'');
-			DB::statement('ALTER TABLE items DROP INDEX ft_item');
-		}else{
+		} else {
 			DB::statement('DROP TABLE items_fts ;');
 		}
 	}

--- a/database/migrations/2014_08_19_164055_create_full_text_search_related_tables.php
+++ b/database/migrations/2014_08_19_164055_create_full_text_search_related_tables.php
@@ -14,15 +14,22 @@ class CreateFullTextSearchRelatedTables extends Migration {
 	 */
 	public function up()
 	{
-		//
-        DB::statement('CREATE VIRTUAL TABLE items_fts USING fts3(item_id, words);');
-        $items = Item::get();
-        foreach($items as $item){
-            $fts = new ItemFts;
-            $fts->item_id = $item->id;
-            $fts->words = FtsUtils::toNgram($item->title . "\n\n" . $item->body);
-            $fts->save();
-        }
+		if(env('DB_DRIVER') === 'mysql'){
+			DB::statement('ALTER TABLE items MODIFY COLUMN title varchar(255)
+                             CHARACTER SET \'utf8mb4\' COLLATE \'utf8mb4_general_ci\'');
+			DB::statement('ALTER TABLE items MODIFY COLUMN body text
+                             CHARACTER SET \'utf8mb4\' COLLATE \'utf8mb4_general_ci\'');
+			DB::statement('ALTER TABLE items ADD FULLTEXT INDEX ft_item (title, body) /*!50100 WITH PARSER `ngram` */');
+		} else {
+			DB::statement('CREATE VIRTUAL TABLE items_fts USING fts3(item_id, words);');
+			$items = Item::get();
+			foreach($items as $item){
+				$fts = new ItemFts;
+				$fts->item_id = $item->id;
+				$fts->words = FtsUtils::toNgram($item->title . "\n\n" . $item->body);
+				$fts->save();
+			}
+		}
 	}
 
 	/**
@@ -32,7 +39,15 @@ class CreateFullTextSearchRelatedTables extends Migration {
 	 */
 	public function down()
 	{
-        DB::statement('DROP TABLE items_fts ;');
+		if(env('DB_DRIVER') === 'mysql') {
+			DB::statement('ALTER TABLE items MODIFY COLUMN title varchar(255)
+                             CHARACTER SET \'utf8mb4\' COLLATE \'utf8mb4_unicode_ci\'');
+			DB::statement('ALTER TABLE items MODIFY COLUMN body text
+                             CHARACTER SET \'utf8mb4\' COLLATE \'utf8mb4_unicode_ci\'');
+			DB::statement('ALTER TABLE items DROP INDEX ft_item');
+		}else{
+			DB::statement('DROP TABLE items_fts ;');
+		}
 	}
 
 }

--- a/database/migrations/2014_10_04_182525_create_item_tag.php
+++ b/database/migrations/2014_10_04_182525_create_item_tag.php
@@ -15,9 +15,9 @@ class CreateItemTag extends Migration {
         Schema::create('item_tag',function($table)
         {
             $table->integer('item_id')->unsigned();
-            $table->foreign('item_id')->references('id')->on('items');
+            $table->foreign('item_id')->references('id')->on('items')->onDelete('cascade');
             $table->integer('tag_id')->unsigned();
-            $table->foreign('tag_id')->references('id')->on('tags');
+            $table->foreign('tag_id')->references('id')->on('tags')->onDelete('cascade');
         });
 	}
 

--- a/database/migrations/2014_10_04_182525_create_item_tag.php
+++ b/database/migrations/2014_10_04_182525_create_item_tag.php
@@ -15,9 +15,9 @@ class CreateItemTag extends Migration {
         Schema::create('item_tag',function($table)
         {
             $table->integer('item_id')->unsigned();
-            $table->foreign('item_id')->references('id')->on('items')->onDelete('cascade');
+            $table->foreign('item_id')->references('id')->on('items');
             $table->integer('tag_id')->unsigned();
-            $table->foreign('tag_id')->references('id')->on('tags')->onDelete('cascade');
+            $table->foreign('tag_id')->references('id')->on('tags');
         });
 	}
 

--- a/database/migrations/2015_01_24_142354_create_tags_fts.php
+++ b/database/migrations/2015_01_24_142354_create_tags_fts.php
@@ -14,7 +14,7 @@ class CreateTagsFts extends Migration {
 	 */
 	public function up()
 	{
-		if(env('DB_DRIVER') === 'mysql'){
+		if (env('DB_DRIVER') === 'mysql') {
             DB::statement('ALTER TABLE tags MODIFY COLUMN name varchar(255)
                          CHARACTER SET \'utf8mb4\' COLLATE \'utf8mb4_general_ci\'');
             DB::statement('ALTER TABLE tags ADD FULLTEXT INDEX ft_tag (name) /*!50100 WITH PARSER `ngram` */');
@@ -37,7 +37,7 @@ class CreateTagsFts extends Migration {
 	 */
 	public function down()
 	{
-		if(env('DB_DRIVER') === 'mysql'){
+		if (env('DB_DRIVER') === 'mysql') {
 			DB::statement('ALTER TABLE tags MODIFY COLUMN name varchar(255)
                              CHARACTER SET \'utf8mb4\' COLLATE \'utf8mb4_unicode_ci\'');
 			DB::statement('ALTER TABLE tags DROP INDEX ft_tag');

--- a/database/migrations/2015_01_24_142354_create_tags_fts.php
+++ b/database/migrations/2015_01_24_142354_create_tags_fts.php
@@ -14,14 +14,20 @@ class CreateTagsFts extends Migration {
 	 */
 	public function up()
 	{
-        DB::statement('CREATE VIRTUAL TABLE tags_fts USING fts3(tag_id, words);');
-        $tags = Tag::get();
-        foreach($tags as $tag){
-            $fts = new TagFts;
-            $fts->tag_id = $tag->id;
-            $fts->words = FtsUtils::toNgram($tag->name);
-            $fts->save();
-        }
+		if(env('DB_DRIVER') === 'mysql'){
+            DB::statement('ALTER TABLE tags MODIFY COLUMN name varchar(255)
+                         CHARACTER SET \'utf8mb4\' COLLATE \'utf8mb4_general_ci\'');
+            DB::statement('ALTER TABLE tags ADD FULLTEXT INDEX ft_tag (name) /*!50100 WITH PARSER `ngram` */');
+		} else {
+			DB::statement('CREATE VIRTUAL TABLE tags_fts USING fts3(tag_id, words);');
+			$tags = Tag::get();
+			foreach ($tags as $tag) {
+				$fts = new TagFts;
+				$fts->tag_id = $tag->id;
+				$fts->words = FtsUtils::toNgram($tag->name);
+				$fts->save();
+			}
+		}
 	}
 
 	/**
@@ -31,7 +37,13 @@ class CreateTagsFts extends Migration {
 	 */
 	public function down()
 	{
-        DB::statement('DROP TABLE tags_fts ;');
+		if(env('DB_DRIVER') === 'mysql'){
+			DB::statement('ALTER TABLE tags MODIFY COLUMN name varchar(255)
+                             CHARACTER SET \'utf8mb4\' COLLATE \'utf8mb4_unicode_ci\'');
+			DB::statement('ALTER TABLE tags DROP INDEX ft_tag');
+		} else {
+			DB::statement('DROP TABLE tags_fts ;');
+		}
 	}
 
 }

--- a/database/migrations/2015_02_27_013908_create_users_table.php
+++ b/database/migrations/2015_02_27_013908_create_users_table.php
@@ -15,7 +15,7 @@ class CreateUsersTable extends Migration {
         Schema::create('users', function(Blueprint $table)
         {
             $table->increments('id');
-            $table->string('username')->after('id')->unique();
+            $table->string('username')->unique();
             $table->string('email')->unique();
             $table->string('password', 60);
             $table->timestamps();

--- a/database/migrations/2015_03_01_010748_create_login_tokens_table.php
+++ b/database/migrations/2015_03_01_010748_create_login_tokens_table.php
@@ -14,10 +14,10 @@ class CreateLoginTokensTable extends Migration {
     {
         Schema::create('login_tokens', function($table) {
             $table->increments('id');
-            $table->integer('user_id')
+            $table->integer('user_id')->unsigned()
                 ->references('id')->on('users')
                 ->onDelete('cascade')->onUpdate('cascade');
-            $table->text('token')->unique();
+            $table->string('token', 512)->unique();
             $table->timestamps();
         });
 	}

--- a/database/migrations/2015_03_01_010748_create_login_tokens_table.php
+++ b/database/migrations/2015_03_01_010748_create_login_tokens_table.php
@@ -12,14 +12,25 @@ class CreateLoginTokensTable extends Migration {
 	 */
 	public function up()
     {
-        Schema::create('login_tokens', function($table) {
-            $table->increments('id');
-            $table->integer('user_id')->unsigned()
-                ->references('id')->on('users')
-                ->onDelete('cascade')->onUpdate('cascade');
-            $table->string('token', 512)->unique();
-            $table->timestamps();
-        });
+        if (env('DB_DRIVER') === 'mysql') {
+            Schema::create('login_tokens', function ($table) {
+                $table->increments('id');
+                $table->integer('user_id')
+                    ->references('id')->on('users')
+                    ->onDelete('cascade')->onUpdate('cascade');
+                $table->string('token', 512)->unique();
+                $table->timestamps();
+            });
+        } else {
+            Schema::create('login_tokens', function ($table) {
+                $table->increments('id');
+                $table->integer('user_id')
+                    ->references('id')->on('users')
+                    ->onDelete('cascade')->onUpdate('cascade');
+                $table->text('token')->unique();
+                $table->timestamps();
+            });
+        }
 	}
 
 	/**

--- a/database/migrations/2015_10_19_010501_create_reminder_tokens_table.php
+++ b/database/migrations/2015_10_19_010501_create_reminder_tokens_table.php
@@ -12,14 +12,25 @@ class CreateReminderTokensTable extends Migration {
 	 */
 	public function up()
 	{
-        Schema::create('reminder_tokens', function($table) {
-            $table->increments('id');
-            $table->integer('user_id')
-                ->references('id')->on('users')
-                ->onDelete('cascade')->onUpdate('cascade');
-            $table->string('token', 512)->unique();
-            $table->timestamps();
-        });
+        if (env('DB_DRIVER') === 'mysql') {
+            Schema::create('reminder_tokens', function($table) {
+                $table->increments('id');
+                $table->integer('user_id')
+                    ->references('id')->on('users')
+                    ->onDelete('cascade')->onUpdate('cascade');
+                $table->string('token', 512)->unique();
+                $table->timestamps();
+            });
+        } else {
+            Schema::create('reminder_tokens', function($table) {
+                $table->increments('id');
+                $table->integer('user_id')
+                    ->references('id')->on('users')
+                    ->onDelete('cascade')->onUpdate('cascade');
+                $table->text('token')->unique();
+                $table->timestamps();
+            });
+        }
 	}
 
 	/**

--- a/database/migrations/2015_10_19_010501_create_reminder_tokens_table.php
+++ b/database/migrations/2015_10_19_010501_create_reminder_tokens_table.php
@@ -17,7 +17,7 @@ class CreateReminderTokensTable extends Migration {
             $table->integer('user_id')
                 ->references('id')->on('users')
                 ->onDelete('cascade')->onUpdate('cascade');
-            $table->text('token')->unique();
+            $table->string('token', 512)->unique();
             $table->timestamps();
         });
 	}

--- a/database/migrations/2015_10_25_220452_alter_user_add_role.php
+++ b/database/migrations/2015_10_25_220452_alter_user_add_role.php
@@ -17,7 +17,7 @@ class AlterUserAddRole extends Migration {
     {
         Schema::table('users', function($table)
         {
-            $table->string('role')->after('password')->default(self::ROLE_ID_MEMBER);
+            $table->string('role')->default(self::ROLE_ID_MEMBER);
         });
 	}
 

--- a/database/migrations/2015_10_25_221700_create_user_roles_table.php
+++ b/database/migrations/2015_10_25_221700_create_user_roles_table.php
@@ -15,7 +15,7 @@ class CreateUserRolesTable extends Migration {
         Schema::create('user_roles', function(Blueprint $table)
         {
             $table->increments('id');
-            $table->string('name')->after('id')->unique();
+            $table->string('name')->unique();
             $table->timestamps();
         });
 	}

--- a/database/migrations/2016_10_13_112743_alter_item_tag_modify_tag_id_cascade.php
+++ b/database/migrations/2016_10_13_112743_alter_item_tag_modify_tag_id_cascade.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AlterItemTagModifyTagIdCascade extends Migration {
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('item_tag', function($table)
+        {
+            $table->dropForeign('item_tag_item_id_foreign');
+            $table->dropForeign('item_tag_tag_id_foreign');
+            $table->foreign('item_id')->references('id')->on('items')->onDelete('cascade');
+            $table->foreign('tag_id')->references('id')->on('tags')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('item_tag', function($table)
+        {
+            $table->dropForeign('item_tag_item_id_foreign');
+            $table->dropForeign('item_tag_tag_id_foreign');
+            $table->foreign('item_id')->references('id')->on('items');
+            $table->foreign('tag_id')->references('id')->on('tags');
+        });
+    }
+
+}


### PR DESCRIPTION
Change mysql setting [strict] false => true
  => avoid migration error for creatd_at default value(0)

Change migration files for MySQL
  1. remove query builder method [after]
    => caused mysql error (may be fixed in Laravel 5.1~)
  2. change token column data type from text  to varchar(512)
    => cannot set unique index for blob data type in MySQL

Add setting in .env.example
  => default sqlite

Sync .env setting int .env.behat
  => add database config

Add MySQL specific repository for fulltext search
  => MySQL/ItemFtsRepository
  => MySQL/TagFtsRepository