### PR TITLE
開発用サービスプロバイダー追加

### DIFF
--- a/app/Providers/DevelopServiceProvider.php
+++ b/app/Providers/DevelopServiceProvider.php
@@ -1,0 +1,59 @@
+<?php namespace Owl\Providers;
+
+/**
+ * @copyright (c) owl
+ */
+
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Class DevelopServiceProvider
+ */
+class DevelopServiceProvider extends ServiceProvider
+{
+    /**
+     * @var array
+     */
+    protected $providers = [
+        'Barryvdh\Debugbar\ServiceProvider',
+    ];
+
+    /**
+     * @var array
+     */
+    protected $facadeAliases = [
+        'Debugbar' => 'Barryvdh\Debugbar\Facade',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function register()
+    {
+        if ($this->app->isLocal()) {
+            $this->registerServiceProviders();
+            $this->registerFacadeAliases();
+        }
+    }
+
+    /**
+     * register service providers
+     */
+    protected function registerServiceProviders()
+    {
+        foreach ($this->providers as $provider) {
+            $this->app->register($provider);
+        }
+    }
+
+    /**
+     * add class aliases
+     */
+    protected function registerFacadeAliases()
+    {
+        $loader = AliasLoader::getInstance();
+        foreach ($this->facadeAliases as $alias => $facade) {
+            $loader->alias($alias, $facade);
+        }
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -140,7 +140,6 @@ return [
        * Libraries Service Providers...
        */
       'Collective\Html\HtmlServiceProvider',
-      'Barryvdh\Debugbar\ServiceProvider',
 
       /*
        * Application Service Providers...
@@ -155,6 +154,7 @@ return [
       'Owl\Providers\ValidatorServiceProvider',
       'Owl\Providers\RepositoriesServiceProvider',
       'Owl\Providers\AuthServiceProvider',
+      'Owl\Providers\DevelopServiceProvider',
 
     ],
 


### PR DESCRIPTION
Issue #170 

`composer require --no-dev`した際にLaravel Debugbarが無くて死んだので開発環境の時のみDebugbarのサービスプロバイダを登録するよう変更しました。